### PR TITLE
Removal of CQC from the Centurion job

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -108,7 +108,6 @@ Centurion
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
-		/obj/item/book/granter/martial/cqc=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/magazine/m10mm_auto=2, \
 		/obj/item/flashlight/flare/torch=1, \


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
No more old manual in their backpack to those that spawned as the Centurion.

## Motivation and Context
Until martial arts are reworked, it will be removed due to balance.

## How Has This Been Tested?
I deleted a line.

## Screenshots (if appropriate):

## Changelog (neccesary)
CQC removal.